### PR TITLE
Added system event TypeSystemChanged (closes #53)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -52,7 +52,7 @@ jobs:
           rust-version: nightly
       - uses: actions-rs/tarpaulin@v0.1
         with:
-          args: -- --all-features --release
+          args: --all-features
       # Note: closed-source code needs to provide a token,
       # but open source code does not.
       - name: Upload to codecov.io

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -52,7 +52,7 @@ jobs:
           rust-version: nightly
       - uses: actions-rs/tarpaulin@v0.1
         with:
-          args: --all-features
+          args: --all-features --release
       # Note: closed-source code needs to provide a token,
       # but open source code does not.
       - name: Upload to codecov.io

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -52,7 +52,7 @@ jobs:
           rust-version: nightly
       - uses: actions-rs/tarpaulin@v0.1
         with:
-          args: --all-features --release
+          args: --all-features
       # Note: closed-source code needs to provide a token,
       # but open source code does not.
       - name: Upload to codecov.io

--- a/src/api/event_manager.rs
+++ b/src/api/event_manager.rs
@@ -7,6 +7,9 @@ use uuid::Uuid;
 use crate::api::Lifecycle;
 use crate::model::ReactiveEntityInstance;
 
+pub const SYSTEM_EVENT_PROPERTY_EVENT: &str = "event";
+pub const SYSTEM_EVENT_PROPERTY_LABEL: &str = "label";
+
 #[derive(Eq, Hash, PartialEq, Clone, Debug)]
 pub enum SystemEventTypes {
     ComponentCreated,
@@ -15,6 +18,10 @@ pub enum SystemEventTypes {
     EntityTypeDeleted,
     RelationTypeCreated,
     RelationTypeDeleted,
+
+    /// The type system has changed
+    TypeSystemChanged,
+
     EntityInstanceCreated,
     EntityInstanceDeleted,
     RelationInstanceCreated,
@@ -30,6 +37,7 @@ pub enum SystemEvent {
     EntityTypeDeleted(String),
     RelationTypeCreated(String),
     RelationTypeDeleted(String),
+    TypeSystemChanged,
     EntityInstanceCreated(Uuid),
     EntityInstanceDeleted(Uuid),
     RelationInstanceCreated(EdgeKey),
@@ -38,9 +46,31 @@ pub enum SystemEvent {
     FlowDeleted(Uuid),
 }
 
+impl From<&SystemEvent> for SystemEventTypes {
+    fn from(event: &SystemEvent) -> Self {
+        match event {
+            SystemEvent::ComponentCreated(_) => SystemEventTypes::ComponentCreated,
+            SystemEvent::ComponentDeleted(_) => SystemEventTypes::ComponentDeleted,
+            SystemEvent::EntityTypeCreated(_) => SystemEventTypes::EntityTypeCreated,
+            SystemEvent::EntityTypeDeleted(_) => SystemEventTypes::EntityTypeDeleted,
+            SystemEvent::RelationTypeCreated(_) => SystemEventTypes::RelationTypeCreated,
+            SystemEvent::RelationTypeDeleted(_) => SystemEventTypes::RelationTypeDeleted,
+            SystemEvent::TypeSystemChanged => SystemEventTypes::TypeSystemChanged,
+            SystemEvent::EntityInstanceCreated(_) => SystemEventTypes::EntityInstanceCreated,
+            SystemEvent::EntityInstanceDeleted(_) => SystemEventTypes::EntityInstanceDeleted,
+            SystemEvent::RelationInstanceCreated(_) => SystemEventTypes::RelationInstanceCreated,
+            SystemEvent::RelationInstanceDeleted(_) => SystemEventTypes::RelationInstanceDeleted,
+            SystemEvent::FlowCreated(_) => SystemEventTypes::FlowCreated,
+            SystemEvent::FlowDeleted(_) => SystemEventTypes::FlowDeleted,
+        }
+    }
+}
+
 #[async_trait]
 pub trait SystemEventManager: Send + Sync + Lifecycle {
     fn emit_event(&self, event: SystemEvent);
 
     fn get_system_event_instances(&self) -> Vec<Arc<ReactiveEntityInstance>>;
+
+    fn get_system_event_instance(&self, event_type: SystemEventTypes) -> Option<Arc<ReactiveEntityInstance>>;
 }


### PR DESCRIPTION
* Adds a new type of `SystemEvent`: `TypeSystemChanged`
* Added converter for `SystemEvent` to `SystemEventTypes`
* A `SystemEvent` is fired automatically if a component, entity type or relation type has been created or deleted
* Added a method for getting the corresponding entity instance for a `SystemEvent` by `SystemEventTypes`
* Improved pattern matching makes it more readable
